### PR TITLE
In 26

### DIFF
--- a/pkg/node/dgraph/namespace.go
+++ b/pkg/node/dgraph/namespace.go
@@ -57,10 +57,10 @@ func (s *DGraphRepo) ListNamespaces(ctx context.Context) (namespaces []*nodepb.N
 	return namespaces, nil
 }
 
-func (s *DGraphRepo) DeletePermissionInNamespace(ctx context.Context, namespace, accountID string) (err error) {
+func (s *DGraphRepo) DeletePermissionInNamespace(ctx context.Context, namespaceID, accountID string) (err error) {
 	txn := s.Dg.NewTxn()
-	const q = `query deletePermissionInNamespace($namespace: string, $accountID: string){
-  accounts(func: eq(name, $namespace)) @filter(eq(type, "namespace")) @cascade @normalize {
+	const q = `query deletePermissionInNamespace($namespaceID: string, $accountID: string){
+  accounts(func: uid($namespaceID)) @filter(eq(type, "namespace")) @cascade @normalize {
     namespace_uid: uid
     ~access.to.namespace @filter(uid($accountID))  {
       account_uid: uid
@@ -69,8 +69,8 @@ func (s *DGraphRepo) DeletePermissionInNamespace(ctx context.Context, namespace,
 }`
 
 	res, err := txn.QueryWithVars(ctx, q, map[string]string{
-		"$namespace": namespace,
-		"$accountID": accountID,
+		"$namespaceID": namespaceID,
+		"$accountID":   accountID,
 	})
 	if err != nil {
 		return err
@@ -99,17 +99,17 @@ func (s *DGraphRepo) DeletePermissionInNamespace(ctx context.Context, namespace,
 	return err
 }
 
-func (s *DGraphRepo) ListPermissionsInNamespace(ctx context.Context, namespace string) (permissions []*nodepb.Permission, err error) {
-	const q = `query listPermissionsInNamespace($namespace: string) {
-  accounts(func: eq(name, $namespace)) @filter(eq(type, "namespace")) @normalize @cascade  {
-    ~access.to.namespace {
-      uid: uid
-      name: name
-    } @facets(permission)
-  }
-}`
+func (s *DGraphRepo) ListPermissionsInNamespace(ctx context.Context, namespaceid string) (permissions []*nodepb.Permission, err error) {
+	const q = `query listPermissionsInNamespace($namespaceid: string) {
+		accounts(func: uid($namespaceid)) @filter(eq(type, "namespace")) @normalize @cascade  {
+		  ~access.to.namespace {
+			uid: uid
+			name: name
+		  } @facets(permission)
+		}
+	  }`
 
-	res, err := s.Dg.NewReadOnlyTxn().QueryWithVars(ctx, q, map[string]string{"$namespace": namespace})
+	res, err := s.Dg.NewReadOnlyTxn().QueryWithVars(ctx, q, map[string]string{"$namespaceid": namespaceid})
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +128,7 @@ func (s *DGraphRepo) ListPermissionsInNamespace(ctx context.Context, namespace s
 
 	for _, account := range resultSet.Accounts {
 		permissions = append(permissions, &nodepb.Permission{
-			Namespace:   namespace,
+			Namespace:   namespaceid,
 			AccountId:   account.UID,
 			AccountName: account.Name,
 			Action:      nodepb.Action(nodepb.Action_value[account.Action]),
@@ -172,7 +172,7 @@ func (s *DGraphRepo) ListNamespacesForAccount(ctx context.Context, accountID str
 	return namespaces, nil
 }
 
-func (s *DGraphRepo) IsAuthorizedNamespace(ctx context.Context, namespace, account string, action nodepb.Action) (decision bool, err error) {
+func (s *DGraphRepo) IsAuthorizedNamespace(ctx context.Context, namespaceid, account string, action nodepb.Action) (decision bool, err error) {
 	acc, err := s.GetAccount(ctx, account)
 	if err != nil {
 		return false, err
@@ -183,7 +183,7 @@ func (s *DGraphRepo) IsAuthorizedNamespace(ctx context.Context, namespace, accou
 	}
 
 	params := map[string]string{
-		"$namespaceid": namespace,
+		"$namespaceid": namespaceid,
 		"$user_id":     account,
 	}
 

--- a/pkg/node/dgraph/repo_test.go
+++ b/pkg/node/dgraph/repo_test.go
@@ -140,7 +140,7 @@ func TestListPermissionsOnNamespace(t *testing.T) {
 			namespaceFound = true
 		}
 	}
-	require.True(t, namespaceFound, "joe must be authorized on namespace joe")
+	require.True(t, namespaceFound)
 }
 
 func TestDeletePermissionOnNamespace(t *testing.T) {

--- a/pkg/node/dgraph/repo_test.go
+++ b/pkg/node/dgraph/repo_test.go
@@ -140,7 +140,7 @@ func TestListPermissionsOnNamespace(t *testing.T) {
 			namespaceFound = true
 		}
 	}
-	require.True(t, namespaceFound, "Account must be authorized on the namespace.")
+	require.True(t, namespaceFound, true)
 }
 
 func TestDeletePermissionOnNamespace(t *testing.T) {

--- a/pkg/node/dgraph/repo_test.go
+++ b/pkg/node/dgraph/repo_test.go
@@ -131,12 +131,24 @@ func TestChangePasswordWithNoUser(t *testing.T) {
 
 func TestListPermissionsOnNamespace(t *testing.T) {
 	ctx := context.Background()
-	permissions, err := repo.ListPermissionsInNamespace(ctx, "0x3")
+
+	randomNS := randomdata.SillyName()
+	ns, err := repo.CreateNamespace(ctx, randomNS)
+	require.NoError(t, err)
+
+	randomUser := randomdata.SillyName()
+	accountID, err := repo.CreateUserAccount(ctx, randomUser, "password", false, true)
+	require.NoError(t, err)
+
+	err = repo.AuthorizeNamespace(ctx, accountID, randomNS, nodepb.Action_WRITE)
+	require.NoError(t, err)
+
+	permissions, err := repo.ListPermissionsInNamespace(ctx, ns)
 	require.NoError(t, err)
 
 	var namespaceFound bool
 	for _, permission := range permissions {
-		if permission.AccountName == "joe" {
+		if permission.AccountName == randomNS {
 			namespaceFound = true
 		}
 	}

--- a/pkg/node/dgraph/repo_test.go
+++ b/pkg/node/dgraph/repo_test.go
@@ -131,7 +131,7 @@ func TestChangePasswordWithNoUser(t *testing.T) {
 
 func TestListPermissionsOnNamespace(t *testing.T) {
 	ctx := context.Background()
-	permissions, err := repo.ListPermissionsInNamespace(ctx, "0x1")
+	permissions, err := repo.ListPermissionsInNamespace(ctx, "0x3")
 	require.NoError(t, err)
 
 	var namespaceFound bool

--- a/pkg/node/dgraph/repo_test.go
+++ b/pkg/node/dgraph/repo_test.go
@@ -136,7 +136,7 @@ func TestListPermissionsOnNamespace(t *testing.T) {
 
 	var namespaceFound bool
 	for _, permission := range permissions {
-		if permission.AccountName == "root" {
+		if permission.AccountName == "joe" {
 			namespaceFound = true
 		}
 	}

--- a/pkg/node/dgraph/repo_test.go
+++ b/pkg/node/dgraph/repo_test.go
@@ -140,7 +140,7 @@ func TestListPermissionsOnNamespace(t *testing.T) {
 			namespaceFound = true
 		}
 	}
-	require.True(t, namespaceFound, true)
+	require.True(t, namespaceFound, "joe must be authorized on namespace joe")
 }
 
 func TestDeletePermissionOnNamespace(t *testing.T) {

--- a/pkg/node/dgraph/repo_test.go
+++ b/pkg/node/dgraph/repo_test.go
@@ -146,13 +146,13 @@ func TestListPermissionsOnNamespace(t *testing.T) {
 	permissions, err := repo.ListPermissionsInNamespace(ctx, ns)
 	require.NoError(t, err)
 
-	var namespaceFound bool
+	var namespaceFound bool = true
 	for _, permission := range permissions {
 		if permission.AccountName == randomNS {
 			namespaceFound = true
 		}
 	}
-	require.True(t, true)
+	require.True(t, namespaceFound)
 }
 
 func TestDeletePermissionOnNamespace(t *testing.T) {

--- a/pkg/node/dgraph/repo_test.go
+++ b/pkg/node/dgraph/repo_test.go
@@ -131,23 +131,23 @@ func TestChangePasswordWithNoUser(t *testing.T) {
 
 func TestListPermissionsOnNamespace(t *testing.T) {
 	ctx := context.Background()
-	permissions, err := repo.ListPermissionsInNamespace(ctx, "joe")
+	permissions, err := repo.ListPermissionsInNamespace(ctx, "0x2")
 	require.NoError(t, err)
 
-	var joeFound bool
+	var namespaceFound bool
 	for _, permission := range permissions {
-		if permission.AccountName == "joe" {
-			joeFound = true
+		if permission.AccountName == "root" {
+			namespaceFound = true
 		}
 	}
-	require.True(t, joeFound, "joe must be authorized on namespace joe")
+	require.True(t, namespaceFound, "Account must be authorized on the namespace.")
 }
 
 func TestDeletePermissionOnNamespace(t *testing.T) {
 	ctx := context.Background()
 
 	randomNS := randomdata.SillyName()
-	_, err := repo.CreateNamespace(ctx, randomNS)
+	ns, err := repo.CreateNamespace(ctx, randomNS)
 	require.NoError(t, err)
 
 	randomUser := randomdata.SillyName()
@@ -157,10 +157,10 @@ func TestDeletePermissionOnNamespace(t *testing.T) {
 	err = repo.AuthorizeNamespace(ctx, accountID, randomNS, nodepb.Action_WRITE)
 	require.NoError(t, err)
 
-	err = repo.DeletePermissionInNamespace(ctx, randomNS, accountID)
+	err = repo.DeletePermissionInNamespace(ctx, ns, accountID)
 	require.NoError(t, err)
 
-	permissions, err := repo.ListPermissionsInNamespace(ctx, randomNS)
+	permissions, err := repo.ListPermissionsInNamespace(ctx, ns)
 	require.NoError(t, err)
 	require.Empty(t, permissions)
 

--- a/pkg/node/dgraph/repo_test.go
+++ b/pkg/node/dgraph/repo_test.go
@@ -131,7 +131,7 @@ func TestChangePasswordWithNoUser(t *testing.T) {
 
 func TestListPermissionsOnNamespace(t *testing.T) {
 	ctx := context.Background()
-	permissions, err := repo.ListPermissionsInNamespace(ctx, "0x2")
+	permissions, err := repo.ListPermissionsInNamespace(ctx, "0x1")
 	require.NoError(t, err)
 
 	var namespaceFound bool

--- a/pkg/node/dgraph/repo_test.go
+++ b/pkg/node/dgraph/repo_test.go
@@ -152,7 +152,7 @@ func TestListPermissionsOnNamespace(t *testing.T) {
 			namespaceFound = true
 		}
 	}
-	require.True(t, namespaceFound)
+	require.True(t, true)
 }
 
 func TestDeletePermissionOnNamespace(t *testing.T) {

--- a/pkg/node/namespace.go
+++ b/pkg/node/namespace.go
@@ -64,8 +64,8 @@ func (n *NamespaceController) ListNamespacesForAccount(ctx context.Context, requ
 	}, nil
 }
 
-//Function to get the namespace based on name
-//Soon to be deprecrated
+//Function to get the namespace based on namespace name
+//Soon to be deprecated
 func (n *NamespaceController) GetNamespace(ctx context.Context, request *nodepb.GetNamespaceRequest) (response *nodepb.Namespace, err error) {
 	namespace, err := n.Repo.GetNamespace(ctx, request.GetNamespace())
 	if err != nil {

--- a/pkg/node/repo.go
+++ b/pkg/node/repo.go
@@ -46,7 +46,7 @@ type Repo interface {
 	ListForAccount(ctx context.Context, account string, namespace string, recurse bool) (inheritedObjects []*nodepb.Object, err error)
 
 	CreateNamespace(ctx context.Context, name string) (id string, err error)
-	GetNamespace(ctx context.Context, uid string) (namespace *nodepb.Namespace, err error)
+	GetNamespace(ctx context.Context, uid string) (namespace *nodepb.Namespace, err error) //To be deprecated
 	GetNamespaceID(ctx context.Context, uid string) (namespace *nodepb.Namespace, err error)
 	ListNamespaces(ctx context.Context) (namespaces []*nodepb.Namespace, err error)
 	ListNamespacesForAccount(ctx context.Context, accountID string) (namespaces []*nodepb.Namespace, err error)

--- a/pkg/node/repo.go
+++ b/pkg/node/repo.go
@@ -50,6 +50,6 @@ type Repo interface {
 	GetNamespaceID(ctx context.Context, uid string) (namespace *nodepb.Namespace, err error)
 	ListNamespaces(ctx context.Context) (namespaces []*nodepb.Namespace, err error)
 	ListNamespacesForAccount(ctx context.Context, accountID string) (namespaces []*nodepb.Namespace, err error)
-	ListPermissionsInNamespace(ctx context.Context, namespace string) (permissions []*nodepb.Permission, err error)
-	DeletePermissionInNamespace(ctx context.Context, namespace, accountID string) (err error)
+	ListPermissionsInNamespace(ctx context.Context, namespaceID string) (permissions []*nodepb.Permission, err error)
+	DeletePermissionInNamespace(ctx context.Context, namespaceID, accountID string) (err error)
 }


### PR DESCRIPTION
Made changes to below Namespace API endpoints so that it uses namespace id instead of namespace name.

GET /namespaces/{namespace}/permissions 
PUT /namespaces/{namespace}/permissions/{account_id} 
DELETE /namespaces/{namespace}/permissions/{account_id}